### PR TITLE
Fix / when ssr apply authentication request

### DIFF
--- a/src/app/developer/wepp/[weppId]/info/page.tsx
+++ b/src/app/developer/wepp/[weppId]/info/page.tsx
@@ -1,17 +1,21 @@
+import { getServerQueryClient } from '@/shared/apis/get-query-client';
 import { weppMineDetailOptions } from '@/shared/apis/queries/wepp';
 import { WeppInfoPage } from '@/views/(developer)/wepp-info';
-import {
-  dehydrate,
-  QueryClient,
-  HydrationBoundary,
-} from '@tanstack/react-query';
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
+import { cookies } from 'next/headers';
 
 const Page = async ({ params }: { params: { weppId: string } }) => {
-  const queryClient = new QueryClient();
+  const queryClient = getServerQueryClient();
+
+  const cookieStore = cookies();
+  const token = cookieStore.get('weppstore_token')?.value;
 
   await queryClient.prefetchQuery(
     weppMineDetailOptions({
       weppId: params.weppId,
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
     })
   );
 

--- a/src/shared/apis/get-query-client.ts
+++ b/src/shared/apis/get-query-client.ts
@@ -9,14 +9,10 @@ const makeQueryClient = () =>
   new QueryClient({
     defaultOptions: {
       queries: {
-        // With SSR, we usually want to set some default staleTime
-        // above 0 to avoid refetching immediately on the client
         staleTime: 60 * 1000,
-        refetchOnReconnect: true, // 네트워크 재연결이 발생한 경우
-        refetchOnWindowFocus: false, // 브라우저에 포커스가 들어온 경우
-        refetchOnMount: true, // 새로운 컴포넌트 마운트가 발생한 경우
-        // staleTime: 0, // 데이터가 fresh -> stale 되는 시간
-        // gcTime: 0, // 캐시된 데이터가 얼마나 오랫동안 메모리에 유지될 것인지
+        refetchOnReconnect: true,
+        refetchOnWindowFocus: false,
+        refetchOnMount: true,
         retry: 0,
       },
       dehydrate: {

--- a/src/shared/apis/queries/wepp/mine-wepp.ts
+++ b/src/shared/apis/queries/wepp/mine-wepp.ts
@@ -12,21 +12,27 @@ import { notFound } from 'next/navigation';
 
 type Props = {
   weppId: string;
+  headers?: { [key: string]: string };
 } & Omit<UseQueryOptions, 'queryKey'>;
 
 export const weppMineDetailOptions = ({
   weppId,
+  headers,
   ...other
 }: Props): UseQueryOptions => ({
   queryKey: weppKeys.mine(weppId),
   queryFn: async () => {
     try {
-      const response = await axiosInstance.get(PATH_API.WEPP.MINE(weppId));
+      const response = await axiosInstance.get(PATH_API.WEPP.MINE(weppId), {
+        headers,
+      });
+
       return response.data;
     } catch (error: any) {
       if (error.statusCode === 404) {
         return notFound();
       }
+
       throw error;
     }
   },


### PR DESCRIPTION
# SSR시 API 요청 헤더에 인증 정보가 들어가지 않는 문제 수정

---

https://github.com/wepp-store/weppstore-fe/commit/7618cf5d632c57099932c4e548aa9fb8e5367ae7

위 커밋에서 개발자 전용 API를 연동하면서
Server side API 요청에 `token`이 필요해졌음.

현재 axios instance에 authorization header 세팅을 클라이언트측에서 하고 있으므로
Next 서버측에서는 **header 값이 없어서 문제가 생김.**

---

## 해결 방안

- `sign in`, `refresh token` 요청시 API 서버측에서 response에 `쿠키`값을 세팅함.
- 클라이언트측에서 페이지 요청에 쿠키를 보내면 **Next 서버 사이드에서 받아서 서버측 요청에 헤더 인증 정보를 추가함.**

