### PR TITLE
Fix / add route handler to using cookie in server side

### DIFF
--- a/src/app/api/refresh/route.ts
+++ b/src/app/api/refresh/route.ts
@@ -1,0 +1,32 @@
+import { axiosInstance } from '@/shared/apis/axios';
+import { PATH_API } from '@/shared/apis/path';
+import { cookies } from 'next/headers';
+
+export async function POST(req: Request) {
+  try {
+    const { refreshToken } = await req.json();
+
+    const cookieStore = cookies();
+
+    const { data } = await axiosInstance.post(PATH_API.AUTH.REFRESH_TOKEN, {
+      refreshToken,
+    });
+
+    cookieStore.set('weppstore_token', data.accessToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax',
+      maxAge: 3600 * 1000,
+    });
+
+    return Response.json(data);
+  } catch (error: any) {
+    if (error.response?.status === 401) {
+      return new Response('Unauthorized request', { status: 401 });
+    }
+
+    return new Response('Internal server ERROR! Something went wrong', {
+      status: 500,
+    });
+  }
+}

--- a/src/app/api/sign-in/route.ts
+++ b/src/app/api/sign-in/route.ts
@@ -1,0 +1,30 @@
+import { axiosInstance } from '@/shared/apis/axios';
+import { PATH_API } from '@/shared/apis/path';
+import { cookies } from 'next/headers';
+
+export async function POST(req: Request) {
+  try {
+    const payload = await req.json();
+
+    const cookieStore = cookies();
+
+    const { data } = await axiosInstance.post(PATH_API.AUTH.SIGN_IN, payload);
+
+    cookieStore.set('weppstore_token', data.accessToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax',
+      maxAge: 3600 * 1000,
+    });
+
+    return Response.json(data);
+  } catch (error: any) {
+    if (error.response?.status === 401) {
+      return new Response('Unauthorized request', { status: 401 });
+    }
+
+    return new Response('Internal server ERROR! Something went wrong', {
+      status: 500,
+    });
+  }
+}

--- a/src/app/developer/wepp/[weppId]/info/page.tsx
+++ b/src/app/developer/wepp/[weppId]/info/page.tsx
@@ -13,9 +13,7 @@ const Page = async ({ params }: { params: { weppId: string } }) => {
   await queryClient.prefetchQuery(
     weppMineDetailOptions({
       weppId: params.weppId,
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
     })
   );
 

--- a/src/shared/apis/queries/auth/auth.ts
+++ b/src/shared/apis/queries/auth/auth.ts
@@ -10,7 +10,7 @@ import {
   UseQueryOptions,
   useQueryClient,
 } from '@tanstack/react-query';
-import { AxiosError } from 'axios';
+import axios, { AxiosError } from 'axios';
 import { axiosInstance } from '../../axios';
 import { PATH_API } from '../../path';
 import { authKeys } from './query-key-factory';
@@ -33,7 +33,13 @@ export const useAuth = (params?: Props) => {
       let user = null;
 
       if (!axiosInstance.defaults.headers.common.Authorization) {
-        const response = await axiosInstance.post(PATH_API.AUTH.REFRESH_TOKEN, {
+        // const response = await axiosInstance.post(PATH_API.AUTH.REFRESH_TOKEN, {
+        //   refreshToken,
+        // });
+        /** Server side에서 first party cookie를 사용하기 위해
+         * route handler 사용
+         */
+        const response = await axios.post('/api/refresh', {
           refreshToken,
         });
 

--- a/src/views/(auth)/login/api/sign-in.ts
+++ b/src/views/(auth)/login/api/sign-in.ts
@@ -11,6 +11,7 @@ import {
 } from '@tanstack/react-query';
 import { useRouter, useSearchParams } from 'next/navigation';
 import toast from 'react-hot-toast';
+import axios from 'axios';
 
 export const useSignIn = <T>(
   options?: Omit<UseMutationOptions<any, any, T>, 'mutationKey'>
@@ -21,8 +22,11 @@ export const useSignIn = <T>(
 
   return useMutation({
     mutationFn: async (payload: T) => {
-      const response = await axiosInstance.post(PATH_API.AUTH.SIGN_IN, payload);
-
+      // const response = await axiosInstance.post(PATH_API.AUTH.SIGN_IN, payload);
+      /** Server side에서 first party cookie를 사용하기 위해
+       * route handler 사용
+       */
+      const response = await axios.post('/api/sign-in', payload);
       const { user, ...token } = response.data;
 
       setSession(token);


### PR DESCRIPTION
# Next 서버에서 쿠키를 사용하기 위한 router handler 추가

기존 백엔드 서버에서 set-cookie를 했을 때
`third-party cookie`로 처리되어 문제가 발생하는 경우가 있음.

그래서 `first-party cookie`를 사용하기 위해
set-cookie를 **Next server로 위임하기 위해** `route handler` 사용

---

## route handler 적용 API

- sign-in
- refresh