### PR TITLE
Fix / add not found page in developer wepp detail page

### DIFF
--- a/src/app/developer/wepp/[weppId]/info/page.tsx
+++ b/src/app/developer/wepp/[weppId]/info/page.tsx
@@ -1,8 +1,9 @@
 import { getServerQueryClient } from '@/shared/apis/get-query-client';
-import { weppMineDetailOptions } from '@/shared/apis/queries/wepp';
+import { weppKeys, weppMineDetailOptions } from '@/shared/apis/queries/wepp';
 import { WeppInfoPage } from '@/views/(developer)/wepp-info';
 import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
 import { cookies } from 'next/headers';
+import { notFound } from 'next/navigation';
 
 const Page = async ({ params }: { params: { weppId: string } }) => {
   const queryClient = getServerQueryClient();
@@ -16,6 +17,12 @@ const Page = async ({ params }: { params: { weppId: string } }) => {
       headers: token ? { Authorization: `Bearer ${token}` } : {},
     })
   );
+
+  const wepp = queryClient.getQueryData(weppKeys.mine(params.weppId));
+
+  if (!wepp) {
+    notFound();
+  }
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>

--- a/src/app/developer/wepp/[weppId]/not-found.tsx
+++ b/src/app/developer/wepp/[weppId]/not-found.tsx
@@ -1,15 +1,19 @@
+import { PATH } from '@/shared/constants';
 import Link from 'next/link';
 
 const NotFound = () => {
   return (
     <div className="size-full flex flex-col items-center justify-center">
       <h1 className="text-9xl font-bold text-blue-500">404</h1>
-      <p className="text-gray-600 mt-4 mb-8">페이지가 존재하지 않습니다.</p>
+      <p className="text-gray-600 mt-4 mb-8">
+        페이지가 존재하지 않거나 접근 권한이 없습니다.
+      </p>
       <Link
-        href="/"
+        replace
+        href={PATH.DEVELOPER.MAIN}
         className="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded"
       >
-        홈으로 이동하기
+        이전 페이지로 이동하기
       </Link>
     </div>
   );

--- a/src/app/developer/wepp/[weppId]/page.tsx
+++ b/src/app/developer/wepp/[weppId]/page.tsx
@@ -1,7 +1,34 @@
+import { getServerQueryClient } from '@/shared/apis/get-query-client';
+import { weppMineDetailOptions, weppKeys } from '@/shared/apis/queries/wepp';
 import { WeppDashboardPage } from '@/views/(developer)/wepp-dashboard';
+import { HydrationBoundary, dehydrate } from '@tanstack/react-query';
+import { cookies } from 'next/headers';
+import { notFound } from 'next/navigation';
 
-const WeppDetail = () => {
-  return <WeppDashboardPage />;
+const WeppDetail = async ({ params }: { params: { weppId: string } }) => {
+  const queryClient = getServerQueryClient();
+
+  const cookieStore = cookies();
+  const token = cookieStore.get('weppstore_token')?.value;
+
+  await queryClient.prefetchQuery(
+    weppMineDetailOptions({
+      weppId: params.weppId,
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+    })
+  );
+
+  const wepp = queryClient.getQueryData(weppKeys.mine(params.weppId));
+
+  if (!wepp) {
+    notFound();
+  }
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <WeppDashboardPage />
+    </HydrationBoundary>
+  );
 };
 
 export default WeppDetail;

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,16 +1,16 @@
-import Link from 'next/link';
-
 const NotFound = () => {
   return (
     <div className="size-full flex flex-col items-center justify-center">
       <h1 className="text-9xl font-bold text-blue-500">404</h1>
-      <p className="text-gray-600 mt-4 mb-8">페이지가 존재하지 않습니다.</p>
-      <Link
+      <p className="text-gray-600 mt-4 mb-8">
+        페이지가 존재하지 않거나 접근 권한이 없습니다.
+      </p>
+      <a
         href="/"
         className="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded"
       >
         홈으로 이동하기
-      </Link>
+      </a>
     </div>
   );
 };


### PR DESCRIPTION
# 개발자 전용 Wepp 상세 화면에 404 페이지 추가

권한이 없거나, 존재하지 않는 페이지에 대한 404 페이지 처리가 없어 추가함.

---

기존 api 처리측에서 404 에러 화면으로 넘기는 처리를 했으나,
클라이언트 컴포넌트인 Authguard로 페이지가 감싸져
페이지가 **SSR이 아닌 서버 컴포넌트로 동작함**.
즉, `notFound` 함수가 동작을 하지 않음.

```typescript
queryFn: async () => {
    try {
      const response = await axiosInstance.get(PATH_API.WEPP.MINE(weppId), {
        headers,
      });

      return response.data;
    } catch (error: any) {
      if (error.statusCode === 404) {
        return notFound();
      }

      throw error;
    }
```

---

임시로 페이지 컴포넌트에서 처리함.

```tsx
const wepp = queryClient.getQueryData(weppKeys.mine(params.weppId));

  if (!wepp) {
    notFound();
  }

  return (
    <HydrationBoundary state={dehydrate(queryClient)}>
      <WeppDashboardPage />
    </HydrationBoundary>
  );
```

---

추후 리뉴얼 단계에서 아예 CSR로 가던지 한꺼번에 처리할 예정