### PR TITLE
Fix / change updated at to released at

### DIFF
--- a/src/shared/types/wepp.ts
+++ b/src/shared/types/wepp.ts
@@ -26,6 +26,7 @@ export interface IWepp {
   url: string;
   createdAt: string;
   updatedAt: string;
+  releasedAt: string | null;
   categories: ICategory[];
   logo: string | null;
   screenshots: WeppScreenshot[];

--- a/src/views/wepp-detail/sections/wepp-detail-additional-info.tsx
+++ b/src/views/wepp-detail/sections/wepp-detail-additional-info.tsx
@@ -12,8 +12,8 @@ interface Props {
 }
 
 const WeppDetailAdditionalInfo = ({ wepp }: Props) => {
-  const updatedDate = (() => {
-    const at = wepp?.updatedAt || wepp?.createdAt;
+  const releasedDate = (() => {
+    const at = wepp?.releasedAt || wepp?.updatedAt;
     if (!at) return '';
     return format(new Date(at), 'yyyy.MM.dd');
   })();
@@ -39,7 +39,7 @@ const WeppDetailAdditionalInfo = ({ wepp }: Props) => {
         </div>
 
         <span className="ml-4 font-bold">·</span>
-        <p className="ml-2 text-gray-500">릴리즈 {updatedDate}</p>
+        <p className="ml-2 text-gray-500">릴리즈 {releasedDate}</p>
 
         <span className="ml-4 font-bold">·</span>
         <p className="ml-2 text-gray-500">버전 {wepp?.version}</p>


### PR DESCRIPTION
# 앱 출시일을 `updatedAt`에서 `releasedAt`으로 변경

기존 출시일을 `updatedAt`으로 사용하고 있었음.

서버단에서 `Wepp` 모델에 `releasedAt` 필드 추가 후  
Front에 적용함