### PR TITLE
Feature / wepp event log install tracking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "react-hook-form": "^7.52.1",
         "react-hot-toast": "^2.4.1",
         "react-intersection-observer": "^9.13.0",
+        "recharts": "^2.15.3",
         "tailwindcss": "^3.4.4",
         "yup": "^1.4.0",
         "zustand": "^4.5.4"
@@ -6234,6 +6235,69 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/eslint": {
       "version": "8.56.10",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
@@ -7942,6 +8006,127 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -8026,6 +8211,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -8235,6 +8426,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/eastasianwidth": {
@@ -9628,6 +9829,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -9650,6 +9857,15 @@
       "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.2.2.tgz",
+      "integrity": "sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.2",
@@ -10380,6 +10596,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/intl-messageformat": {
@@ -12512,6 +12737,21 @@
         }
       }
     },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-style-singleton": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
@@ -12552,6 +12792,22 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -12572,6 +12828,53 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.3",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.3.tgz",
+      "integrity": "sha512-EdOPzTwcFSuqtvkDoaM5ws/Km1+WTAO2eizL7rqiG0V2UVhTnz0m7J2i0CjVPUCdEkZImaWvXLbZDS2H5t6GFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/recharts/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/recharts/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/redux": {
       "version": "4.2.1",
@@ -14129,6 +14432,28 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
     },
     "node_modules/watchpack": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "react-hook-form": "^7.52.1",
     "react-hot-toast": "^2.4.1",
     "react-intersection-observer": "^9.13.0",
+    "recharts": "^2.15.3",
     "tailwindcss": "^3.4.4",
     "yup": "^1.4.0",
     "zustand": "^4.5.4"

--- a/src/app/(end-user)/wepps/[weppId]/page.tsx
+++ b/src/app/(end-user)/wepps/[weppId]/page.tsx
@@ -62,7 +62,6 @@ export default async function Page({ params }: Props) {
   await queryClient.prefetchQuery(
     weppDetailOptions({
       weppId: params.weppId,
-      read: true,
       gcTime: Infinity,
       staleTime: Infinity,
     })

--- a/src/app/api/refresh/route.ts
+++ b/src/app/api/refresh/route.ts
@@ -1,5 +1,6 @@
 import { axiosInstance } from '@/shared/apis/axios';
 import { PATH_API } from '@/shared/apis/path';
+import { STORAGE_KEYS } from '@/shared/constants';
 import { cookies } from 'next/headers';
 
 function jwtDecode(token: string) {
@@ -23,7 +24,7 @@ export async function POST(req: Request) {
 
     const { exp, iat } = jwtDecode(data.accessToken);
 
-    cookieStore.set('weppstore_token', data.accessToken, {
+    cookieStore.set(STORAGE_KEYS.TOKEN.ACCESS, data.accessToken, {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
       sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax',

--- a/src/app/api/sign-in/route.ts
+++ b/src/app/api/sign-in/route.ts
@@ -1,5 +1,6 @@
 import { axiosInstance } from '@/shared/apis/axios';
 import { PATH_API } from '@/shared/apis/path';
+import { STORAGE_KEYS } from '@/shared/constants';
 import { cookies } from 'next/headers';
 
 function jwtDecode(token: string) {
@@ -25,14 +26,14 @@ export async function POST(req: Request) {
     const decodedAccessToken = jwtDecode(data.accessToken);
     const decodedRefreshToken = jwtDecode(data.refreshToken);
 
-    cookieStore.set('weppstore_token', data.accessToken, {
+    cookieStore.set(STORAGE_KEYS.TOKEN.ACCESS, data.accessToken, {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
       sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax',
       maxAge: remainingSeconds(decodedAccessToken) || 0,
     });
 
-    cookieStore.set('weppstore_refresh_token', data.refreshToken, {
+    cookieStore.set(STORAGE_KEYS.TOKEN.REFRESH, data.refreshToken, {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
       sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax',

--- a/src/features/delete-wepp/ui/delete-wepp-button.tsx
+++ b/src/features/delete-wepp/ui/delete-wepp-button.tsx
@@ -17,7 +17,12 @@ const DeleteWeppButton = () => {
 
   return (
     <>
-      <Button color="danger" variant="bordered" onPress={onOpenChange}>
+      <Button
+        color="danger"
+        variant="bordered"
+        onPress={onOpenChange}
+        radius="sm"
+      >
         삭제하기
       </Button>
 

--- a/src/shared/apis/path.ts
+++ b/src/shared/apis/path.ts
@@ -24,12 +24,14 @@ export const PATH_API = {
   },
   WEPP: {
     ROOT: '/wepp',
+    DETAIL: (weppId: string) => `/wepp/${weppId}` as const,
     MINE_LIST: '/wepp/mine-list',
     MINE: (weppId: string) => `/wepp/mine/${weppId}` as const,
     SUBMIT: '/wepp/submit',
     VERIFY: '/wepp/verify',
     UPLOAD: '/wepp/upload',
     CLEAR_URL: '/wepp/clear-url',
+    EVENT_LOG: '/wepp/event',
   },
   COMMENT: {
     ROOT: '/comments',

--- a/src/shared/apis/queries/wepp/event-logs.ts
+++ b/src/shared/apis/queries/wepp/event-logs.ts
@@ -1,0 +1,53 @@
+import {
+  useQuery,
+  UseQueryResult,
+  UseQueryOptions,
+} from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+import { PATH_API } from '../../path';
+import { axiosInstance } from '../../axios';
+import { weppKeys } from './query-key-factory';
+import { notFound } from 'next/navigation';
+
+type Props = {
+  weppId: string;
+  from?: string;
+  to?: string;
+} & Omit<UseQueryOptions, 'queryKey'>;
+
+interface ResponseType {
+  date: string;
+  devicePlatform: string;
+  deviceType: string;
+  view: number;
+  install: number;
+}
+
+export const useEventLogs = ({ weppId, from, to, ...other }: Props) => {
+  return useQuery({
+    queryKey: weppKeys.eventLogs(weppId, from, to),
+    queryFn: async () => {
+      try {
+        const response = await axiosInstance.get(PATH_API.WEPP.EVENT_LOG, {
+          params: {
+            wepp_id: weppId,
+            from,
+            to,
+          },
+        });
+
+        return response.data;
+      } catch (error: any) {
+        if (error.statusCode === 404) {
+          return notFound();
+        }
+
+        throw error;
+      }
+    },
+    enabled: !!weppId,
+    staleTime: Infinity,
+    gcTime: Infinity,
+    ...other,
+  }) as UseQueryResult<ResponseType[], AxiosError>;
+};

--- a/src/shared/apis/queries/wepp/query-key-factory.ts
+++ b/src/shared/apis/queries/wepp/query-key-factory.ts
@@ -5,4 +5,6 @@ export const weppKeys = {
   detail: (weppId: string) => [...weppKeys.all, weppId] as const,
   mineList: [PATH_API.WEPP.MINE_LIST] as const,
   mine: (weppId: string) => [...weppKeys.mineList, weppId] as const,
+  eventLogs: (weppId: string, from?: string, to?: string) =>
+    [...weppKeys.all, PATH_API.WEPP.EVENT_LOG, weppId, from, to] as const,
 };

--- a/src/shared/apis/queries/wepp/wepp-detail.ts
+++ b/src/shared/apis/queries/wepp/wepp-detail.ts
@@ -12,27 +12,16 @@ import { notFound } from 'next/navigation';
 
 type Props = {
   weppId: string;
-  read?: boolean;
 } & Omit<UseQueryOptions, 'queryKey'>;
 
 export const weppDetailOptions = ({
   weppId,
-  read = false,
   ...other
 }: Props): UseQueryOptions => ({
   queryKey: weppKeys.detail(weppId),
   queryFn: async () => {
     try {
-      const response = await axiosInstance.get(
-        `${PATH_API.WEPP.ROOT}/${weppId}`,
-        {
-          headers: {
-            'X-WEPP-READ': read,
-            // TODO: 작동하나?
-            'Cache-Control': 'max-age=3600, must-revalidate', // 1시간 동안 캐시 유지
-          },
-        }
-      );
+      const response = await axiosInstance.get(PATH_API.WEPP.DETAIL(weppId));
       return response.data;
     } catch (error: any) {
       if (error.statusCode === 404) {
@@ -45,8 +34,9 @@ export const weppDetailOptions = ({
   ...other,
 });
 
-export const useWeppDetail = ({ weppId, read = false, ...other }: Props) => {
-  return useQuery(
-    weppDetailOptions({ weppId, read, ...other })
-  ) as UseQueryResult<IWepp, AxiosError>;
+export const useWeppDetail = ({ weppId, ...other }: Props) => {
+  return useQuery(weppDetailOptions({ weppId, ...other })) as UseQueryResult<
+    IWepp,
+    AxiosError
+  >;
 };

--- a/src/shared/apis/services/wepp/event-log.ts
+++ b/src/shared/apis/services/wepp/event-log.ts
@@ -1,0 +1,51 @@
+import { axiosInstance } from '../../axios';
+import { IWeppEventLog } from '@/shared/types';
+import { PATH_API } from '../../path';
+import { STORAGE_KEYS } from '@/shared/constants';
+
+interface Payload {
+  weppId: string;
+  eventType: IWeppEventLog['eventType'];
+}
+
+const safetyParse = (key: string) => {
+  const data = sessionStorage.getItem(key);
+  if (!data) return [];
+  try {
+    return JSON.parse(data);
+  } catch (error) {
+    return [];
+  }
+};
+
+/**
+ * 조회수, 설치 버튼 클릭 수 이벤트 로그 생성 함수.
+ * session storage를 사용해서 중복을 방지한다.
+ */
+export const createWeppEventLog = async (payload: Payload) => {
+  const prevLogs = safetyParse(STORAGE_KEYS.WEPP_EVENT_LOGS);
+
+  const isDuplicate = prevLogs.some((log: Payload) => {
+    return log.weppId === payload.weppId && log.eventType === payload.eventType;
+  });
+
+  if (isDuplicate) {
+    return;
+  }
+
+  try {
+    // 중복이 아닐 경우, session storage에 추가
+    const { data } = await axiosInstance.post(PATH_API.WEPP.EVENT_LOG, payload);
+    const newLogs = [...prevLogs, payload];
+
+    sessionStorage.setItem(
+      STORAGE_KEYS.WEPP_EVENT_LOGS,
+      JSON.stringify(newLogs)
+    );
+    return data;
+  } catch (error) {
+    // 실패 해도 아무 것도 안 할래.
+    // fallback으로 다른 곳에 남겨놔서 다음 접속시 요청을 보내도 됨.
+    console.error('Error creating event log:', error);
+  }
+};

--- a/src/shared/constants/constants.ts
+++ b/src/shared/constants/constants.ts
@@ -2,3 +2,11 @@ export const ELEMENT_ID = {
   MAIN_LIST_SECTION: 'main-list-section',
   CREATE_COMMENT_FIELD: 'create-comment-field',
 };
+
+export const STORAGE_KEYS = {
+  TOKEN: {
+    ACCESS: 'weppstore_token',
+    REFRESH: 'weppstore_refresh_token',
+  },
+  WEPP_EVENT_LOGS: 'wepp_event_logs',
+};

--- a/src/shared/constants/routes.ts
+++ b/src/shared/constants/routes.ts
@@ -14,7 +14,8 @@ export const PATH = {
   DEVELOPER: {
     MAIN: '/developer/wepp',
     WEPP: '/developer/wepp',
-    WEPP_DETAIL: (weppId: string) => `/developer/wepp/${weppId}`,
+    WEPP_DASHBOARD: (weppId: string) => `/developer/wepp/${weppId}`,
+    WEPP_DETAIL: (weppId: string) => `/developer/wepp/${weppId}/info`,
     MAKE_PWA: '/developer/make-pwa',
   },
 };

--- a/src/shared/types/wepp.ts
+++ b/src/shared/types/wepp.ts
@@ -41,4 +41,12 @@ export interface IWepp {
     comments: number;
     likes: number;
   };
+  viewCount: number;
+  installCount?: number;
+}
+
+export interface IWeppEventLog {
+  id: number;
+  weppId: string;
+  eventType: 'VIEW' | 'INSTALL';
 }

--- a/src/views/(developer)/main/ui/developer-wepp-card.tsx
+++ b/src/views/(developer)/main/ui/developer-wepp-card.tsx
@@ -10,12 +10,12 @@ interface Props {
 }
 
 const DeveloperWeppCard = ({ wepp }: Props) => {
-  const { id, logo, name, tagLine, _count, views, status } = wepp;
+  const { id, logo, name, tagLine, _count, status } = wepp;
 
   return (
     <Card
       as={Link}
-      href={PATH.DEVELOPER.WEPP_DETAIL(id)}
+      href={PATH.DEVELOPER.WEPP_DASHBOARD(id)}
       isPressable
       className="border-none shadow-none bg-gray-100 hover:bg-gray-200 transition-all duration-200 ease-in-out"
     >
@@ -58,13 +58,6 @@ const DeveloperWeppCard = ({ wepp }: Props) => {
             >
               <MessageCircle size={12} />
               {_count?.comments || 0}
-            </span>
-            <span
-              className="flex items-center gap-1 text-gray-500"
-              aria-label="댓글 수"
-            >
-              <Eye size={12} />
-              {views || 0}
             </span>
           </div>
         </div>

--- a/src/views/(developer)/wepp-dashboard/sections/index.ts
+++ b/src/views/(developer)/wepp-dashboard/sections/index.ts
@@ -1,4 +1,5 @@
 export { default as WeppDashboardInfo } from './wepp-dashboard-info';
+export { default as WeppDashboardChart } from './wepp-dashboard-chart';
 export { default as WeppDashboardHeader } from './wepp-dashboard-header';
 export { default as WeppDashboardStatistics } from './wepp-dashboard-statistics';
 export { default as WeppDashboardBreadcrumbs } from './wepp-dashboard-breadcrumbs';

--- a/src/views/(developer)/wepp-dashboard/sections/wepp-dashboard-chart/index.tsx
+++ b/src/views/(developer)/wepp-dashboard/sections/wepp-dashboard-chart/index.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import React from 'react';
+import { useEventLogs } from '@/shared/apis/queries/wepp/event-logs';
+import {
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+  AreaChart,
+  Area,
+} from 'recharts';
+import { useParams } from 'next/navigation';
+import { Section } from '@/shared/ui/section';
+import { Select, SelectItem, Tab, Tabs } from '@nextui-org/react';
+import {
+  enrichChartData,
+  getKeysByFilter,
+  LABEL_MAP,
+  LINE_COLORS,
+  SUB_FILTERS,
+} from './utils';
+import { FilterType, SubFilterType } from './types';
+
+// ----------------------------------------------------------------------
+
+const CustomLegend = ({ payload }: any) => (
+  <div className="flex gap-4 text-sm mt-2 flex-wrap justify-center">
+    {payload.map((entry: any) => (
+      <div key={entry.dataKey} className="flex items-center gap-1">
+        <div
+          className="w-3 h-3 rounded-full"
+          style={{ backgroundColor: entry.color }}
+        />
+        {LABEL_MAP[entry.dataKey] ?? entry.dataKey}
+      </div>
+    ))}
+  </div>
+);
+
+const CustomTooltip = ({ active, payload, label }: any) => {
+  if (!active || !payload || payload.length === 0) return null;
+
+  return (
+    <div className="bg-white p-2 rounded shadow text-sm border border-gray-300">
+      <p className="font-semibold">{label}</p>
+      <ul className="space-y-1 mt-1">
+        {payload.map((entry: any) => (
+          <li key={entry.dataKey} style={{ color: entry.color }}>
+            {LABEL_MAP[entry.dataKey] ?? entry.dataKey}: {entry.value}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+// ----------------------------------------------------------------------
+
+const WeppDashboardChart = () => {
+  const { weppId }: { weppId: string } = useParams();
+  const { data: eventLogs } = useEventLogs({ weppId });
+
+  const [filter, setFilter] = React.useState<FilterType>('all');
+  const [subFilter, setSubFilter] = React.useState<SubFilterType>('device');
+
+  const chartData = React.useMemo(() => {
+    if (!eventLogs) return [];
+    return enrichChartData(eventLogs);
+  }, [eventLogs]);
+
+  const keysByFilter = React.useMemo(
+    () => getKeysByFilter(filter, subFilter),
+    [filter, subFilter]
+  );
+
+  return (
+    <Section className="mt-8">
+      <div className="flex justify-between mb-4 items-center">
+        <Tabs
+          size="sm"
+          radius="sm"
+          aria-label="필터"
+          selectedKey={filter}
+          onSelectionChange={(key) => setFilter(key as FilterType)}
+        >
+          <Tab key="all" title="전체" />
+          <Tab key="view" title="조회수" />
+          <Tab key="install" title="설치수" />
+        </Tabs>
+
+        {filter !== 'all' && (
+          <Select
+            aria-label="필터 선택"
+            className="w-28"
+            placeholder="필터 선택"
+            size="sm"
+            selectedKeys={[subFilter]}
+            onChange={(e) => {
+              setSubFilter(e.target.value as 'platform' | 'device');
+            }}
+          >
+            {SUB_FILTERS.map((subFilter) => (
+              <SelectItem key={subFilter.key} textValue={subFilter.label}>
+                {subFilter.label}
+              </SelectItem>
+            ))}
+          </Select>
+        )}
+      </div>
+
+      <ResponsiveContainer width="100%" height={300}>
+        <AreaChart data={chartData}>
+          <defs>
+            {keysByFilter.map((key) => (
+              <linearGradient
+                id={`fill_${key}`}
+                key={key}
+                x1="0"
+                y1="0"
+                x2="0"
+                y2="1"
+              >
+                <stop
+                  offset="5%"
+                  stopColor={LINE_COLORS[key]}
+                  stopOpacity={0.7}
+                />
+                <stop
+                  offset="95%"
+                  stopColor={LINE_COLORS[key]}
+                  stopOpacity={0.1}
+                />
+              </linearGradient>
+            ))}
+          </defs>
+
+          <XAxis dataKey="date" />
+          <YAxis allowDecimals={false} />
+          <Tooltip content={<CustomTooltip />} />
+          <Legend content={<CustomLegend />} />
+
+          {keysByFilter.map((key) => (
+            <Area
+              key={key}
+              type="monotone"
+              dataKey={key}
+              stroke={LINE_COLORS[key]}
+              fill={`url(#fill_${key})`}
+              strokeWidth={2}
+            />
+          ))}
+        </AreaChart>
+      </ResponsiveContainer>
+    </Section>
+  );
+};
+
+export default WeppDashboardChart;

--- a/src/views/(developer)/wepp-dashboard/sections/wepp-dashboard-chart/types.ts
+++ b/src/views/(developer)/wepp-dashboard/sections/wepp-dashboard-chart/types.ts
@@ -1,0 +1,2 @@
+export type FilterType = 'all' | 'view' | 'install';
+export type SubFilterType = 'platform' | 'device';

--- a/src/views/(developer)/wepp-dashboard/sections/wepp-dashboard-chart/utils.ts
+++ b/src/views/(developer)/wepp-dashboard/sections/wepp-dashboard-chart/utils.ts
@@ -1,0 +1,95 @@
+/**
+ *  platform별
+ * @platform_ios_view
+ * @platform_ios_install
+ * @platform_other_view
+ * @platform_other_install
+ *  device type별
+ * @device_desktop_view
+ * @device_desktop_install
+ * @device_mobile_view
+ * @device_mobile_install
+ * @device_other_view
+ * @device_other_install
+ */
+
+import { FilterType, SubFilterType } from './types';
+
+export const SUB_FILTERS = [
+  { key: 'device', label: '기기별' },
+  { key: 'platform', label: '플랫폼별' },
+];
+
+export const LINE_COLORS: Record<string, string> = {
+  // all
+  view: '#8884d8',
+  install: '#82ca9d',
+  // platform
+  platform_ios_view: '#8884d8',
+  platform_ios_install: '#8884d8',
+  platform_other_view: '#9c27b0',
+  platform_other_install: '#9c27b0',
+  // device
+  device_mobile_view: '#00bcd4',
+  device_mobile_install: '#00bcd4',
+  device_desktop_view: '#ff9800',
+  device_desktop_install: '#ff9800',
+  device_other_view: '#9e9e9e',
+  device_other_install: '#9e9e9e',
+};
+
+export const LABEL_MAP: Record<string, string> = {
+  // all
+  view: '조회수',
+  install: '설치수',
+  // platform
+  platform_ios_view: 'iOS',
+  platform_ios_install: 'iOS',
+  platform_other_view: '기타',
+  platform_other_install: '기타',
+  // device
+  device_mobile_view: '모바일',
+  device_mobile_install: '모바일',
+  device_desktop_view: '데스크탑',
+  device_desktop_install: '데스크탑',
+  device_other_view: '기타',
+  device_other_install: '기타',
+};
+
+export const getKeysByFilter = (
+  filter: FilterType,
+  subFilter: SubFilterType
+) => {
+  const platformBase = ['ios', 'other'];
+  const deviceBase = ['desktop', 'mobile', 'other'];
+
+  if (filter === 'all') return ['view', 'install'];
+
+  if (subFilter === 'platform')
+    return platformBase.map((b) => `platform_${b}_${filter}`);
+  if (subFilter === 'device')
+    return deviceBase.map((b) => `device_${b}_${filter}`);
+
+  return ['view', 'install']; // ALL
+};
+
+export const enrichChartData = (raw: any[]): any[] => {
+  return raw.map((entry) => {
+    // platform별만 합산해도 총 값이 나옴.
+    const view = ['platform_ios_view', 'platform_other_view'].reduce(
+      (acc, key) => acc + (entry[key] ?? 0),
+      0
+    );
+
+    const install = ['platform_ios_install', 'platform_other_install'].reduce(
+      (acc, key) => acc + (entry[key] ?? 0),
+      0
+    );
+
+    return {
+      ...entry,
+      view,
+      install,
+    };
+  });
+};

--- a/src/views/(developer)/wepp-dashboard/sections/wepp-dashboard-header.tsx
+++ b/src/views/(developer)/wepp-dashboard/sections/wepp-dashboard-header.tsx
@@ -1,9 +1,12 @@
 'use client';
+
 import { DeleteWeppButton } from '@/features/delete-wepp';
-import { PATH_API } from '@/shared/apis/path';
 import { weppKeys } from '@/shared/apis/queries/wepp';
+import { PATH } from '@/shared/constants';
 import { IWepp } from '@/shared/types';
 import { Section } from '@/shared/ui/section';
+import { weppStatusToColor, weppStatusToText } from '@/shared/utils';
+import { Button, Chip, Link } from '@nextui-org/react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useParams } from 'next/navigation';
 import React from 'react';
@@ -18,11 +21,30 @@ const WeppDashboardHeader = () => {
   return (
     <Section>
       <header className="flex justify-between">
-        <h1 className="text-3xl font-bold text-gray-800">
-          {wepp?.name} 대시보드
-        </h1>
+        <div className="flex gap-2 items-center">
+          <h1 className="text-3xl font-bold text-gray-800">
+            {wepp?.name} 대시보드
+          </h1>
+          <Chip
+            color={weppStatusToColor(wepp?.status)}
+            variant="flat"
+            className="rounded-md"
+          >
+            {weppStatusToText(wepp?.status)}
+          </Chip>
+        </div>
 
-        <DeleteWeppButton />
+        <div className="flex gap-4 items-center">
+          <Button
+            href={PATH.DEVELOPER.WEPP_DETAIL(weppId)}
+            as={Link}
+            variant="bordered"
+            radius="sm"
+          >
+            수정하기
+          </Button>
+          <DeleteWeppButton />
+        </div>
       </header>
     </Section>
   );

--- a/src/views/(developer)/wepp-dashboard/sections/wepp-dashboard-statistics.tsx
+++ b/src/views/(developer)/wepp-dashboard/sections/wepp-dashboard-statistics.tsx
@@ -12,41 +12,39 @@ const WeppDashboardStatistics = () => {
 
   const { data: wepp } = useMineWeppDetail({ weppId });
 
-  const { views, _count } = wepp ?? {};
+  const { _count, viewCount, installCount } = wepp ?? {};
 
   return (
     <Section>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
         <Card className="p-4 flex-row items-center gap-6 border border-gray-200 rounded-md shadow-none">
-          <Eye className="w-8 h-8 text-green-500" />
+          <Eye className="text-green-500" size={24} />
           <div>
             <p className="text-sm text-muted-foreground">총 조회 수</p>
-            <p className="text-xl font-semibold">{views ?? 0}회</p>
+            <p className="text-xl font-semibold">{viewCount ?? 0}회</p>
           </div>
         </Card>
         <Card className="p-4 flex-row items-center gap-6 border border-gray-200 rounded-md shadow-none">
-          <Heart className="w-8 h-8 text-blue-500" />
+          <Heart className="text-red-500" size={24} />
           <div>
             <p className="text-sm text-muted-foreground">총 좋아요 수</p>
             <p className="text-xl font-semibold">{_count?.likes ?? 0}회</p>
           </div>
         </Card>
         <Card className="p-4 flex-row items-center gap-6 border border-gray-200 rounded-md shadow-none">
-          <MessageCircle className="w-8 h-8 text-purple-500" />
+          <MessageCircle className="text-purple-500" size={24} />
           <div>
             <p className="text-sm text-muted-foreground">총 댓글 수</p>
             <p className="text-xl font-semibold">{_count?.comments ?? 0}개</p>
           </div>
         </Card>
         <Card className="p-4 flex-row items-center gap-6 border border-gray-200 rounded-md shadow-none">
-          <BarChart2 className="w-8 h-8 text-purple-500" />
+          <BarChart2 className="text-blue-500" size={24} />
           <div>
             <p className="text-sm text-muted-foreground">
               총 설치 버튼 클릭 수
             </p>
-            <p className="text-xl font-semibold">
-              <del className="text-gray-600">작업 중입니다.</del>
-            </p>
+            <p className="text-xl font-semibold">{installCount ?? 0}회</p>
           </div>
         </Card>
       </div>

--- a/src/views/(developer)/wepp-dashboard/wepp-dashboard-page.tsx
+++ b/src/views/(developer)/wepp-dashboard/wepp-dashboard-page.tsx
@@ -1,8 +1,8 @@
 import {
-  WeppDashboardInfo,
   WeppDashboardHeader,
   WeppDashboardBreadcrumbs,
   WeppDashboardStatistics,
+  WeppDashboardChart,
 } from './sections';
 
 const WeppDashboardPage = () => {
@@ -11,7 +11,7 @@ const WeppDashboardPage = () => {
       <WeppDashboardBreadcrumbs />
       <WeppDashboardHeader />
       <WeppDashboardStatistics />
-      <WeppDashboardInfo />
+      <WeppDashboardChart />
     </>
   );
 };

--- a/src/views/wepp-detail/ui/wepp-install-button.tsx
+++ b/src/views/wepp-detail/ui/wepp-install-button.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { createWeppEventLog } from '@/shared/apis/services/wepp/event-log';
 import { BrowserShare } from '@/shared/assets/icons';
 import useDevice from '@/shared/hooks/use-device';
 import { IWepp } from '@/shared/types';
@@ -23,13 +24,19 @@ interface Props extends ButtonProps {
 }
 
 const WeppInstallButton = ({ wepp, ...other }: Props) => {
-  const { url, isVerified } = wepp || {};
+  const { url, isVerified, id } = wepp || {};
 
   const { isIOS } = useDevice();
 
   const { isOpen, onOpenChange, onClose } = useDisclosure();
 
   const weppInstallLink = installLink(url);
+
+  // 설치 이벤트 로그를 기록
+  const onCreateInstallEventLog = () => {
+    if (!id) return;
+    createWeppEventLog({ weppId: id, eventType: 'INSTALL' });
+  };
 
   const modalRenderContent = () => {
     if (isIOS) {
@@ -54,6 +61,7 @@ const WeppInstallButton = ({ wepp, ...other }: Props) => {
               as={Link}
               href={weppInstallLink}
               target="_blank"
+              onClick={onCreateInstallEventLog}
             >
               받기
             </Button>
@@ -83,6 +91,7 @@ const WeppInstallButton = ({ wepp, ...other }: Props) => {
             as={Link}
             href={weppInstallLink}
             target="_blank"
+            onClick={onCreateInstallEventLog}
           >
             받기
           </Button>
@@ -99,6 +108,7 @@ const WeppInstallButton = ({ wepp, ...other }: Props) => {
         as={Link}
         target="_blank"
         href={weppInstallLink}
+        onClick={onCreateInstallEventLog}
         {...other}
       >
         받기

--- a/src/views/wepp-detail/ui/wepp-view-event-log.tsx
+++ b/src/views/wepp-detail/ui/wepp-view-event-log.tsx
@@ -1,0 +1,17 @@
+import { createWeppEventLog } from '@/shared/apis/services/wepp/event-log';
+import React from 'react';
+
+interface Props {
+  weppId: string;
+}
+
+const WeppViewEventLog = ({ weppId }: Props) => {
+  React.useEffect(() => {
+    if (!weppId) return;
+    createWeppEventLog({ weppId, eventType: 'VIEW' });
+  }, [weppId]);
+
+  return null;
+};
+
+export default WeppViewEventLog;

--- a/src/views/wepp-detail/wepp-detail-page.tsx
+++ b/src/views/wepp-detail/wepp-detail-page.tsx
@@ -1,4 +1,5 @@
 'use client';
+
 import { useWeppDetail } from '@/shared/apis/queries/wepp';
 import { useParams, useRouter } from 'next/navigation';
 import {
@@ -14,6 +15,7 @@ import { Divider, Link } from '@nextui-org/react';
 import { Section } from '@/shared/ui/section';
 import { ChevronLeft } from 'lucide-react';
 import { ELEMENT_ID, PATH } from '@/shared/constants';
+import WeppViewEventLog from './ui/wepp-view-event-log';
 
 const WeppDetailScreen = () => {
   const { replace } = useRouter();
@@ -70,6 +72,9 @@ const WeppDetailScreen = () => {
 
       {/* 비슷한 앱 추천 */}
       {/* <WeppDetailSimilars /> */}
+
+      {/* 조회수 증가를 위한 이벤트 로그 */}
+      <WeppViewEventLog weppId={weppId} />
     </article>
   );
 };


### PR DESCRIPTION
# 조회수 로직 개선 등 이벤트 로그 처리 로직 변경

기존에는 조회수 증가가 필요한 경우 header에 `X-wepp-read=true`를 추가해서 보내고,  
서버에서 이를 받아 `redis`에 저장 후 10분 간격으로 배치처리를 하는 방식이었다.  

그러나, **설치 버튼 클릭 수** 기능을 도입하게 되면서 개발자 입장에서의 데이터 분석 기능을 고려하게 됐다.   
그래서 `Event Logging`을 추가하였고, 이에 따라 조회수 상승 로직을 변경했다.  


## Server

- WeppEventLog 엔티티 추가 (현재는 `조회수`, `설치 클릭 수`)만 로깅함.
- 기존 조회수 캐싱 및 배치 처리 로직 제거
- ~~IP, UserAgent 기반 중복 이벤트 로깅 방지~~ 중복 이슈가 있어 추후 고려
- 기기 / 플랫폼별 로깅 분류

---

## Client

- 조회수, 설치 버튼 클릭 수 기반 날짜별(최근 30일) 차트 제공
- 전체 / 조회수 / 클릭수 -> 기기 / 플랫폼별 **filtered chart** 제공
- 사용자 입장에서 앱 상세 페이지 진입시 `조회수 이벤트` 로깅
- 설치 버튼 클릭시 `설치 버튼 클릭 이벤트` 로깅
- `sessionStorage` 기반 같은 탭에서 중복 이벤트 로깅 방지

![image](https://github.com/user-attachments/assets/9e3617b3-8fdf-45d7-98e0-2d98fb147e2d)

