### PR TITLE
Feature / add dark mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "next": "14.2.3",
         "next-nprogress-bar": "^2.3.13",
         "next-pwa": "^5.6.0",
+        "next-themes": "^0.4.6",
         "postcss": "^8.4.39",
         "prism-react-renderer": "^2.3.1",
         "react": "^18",
@@ -11747,6 +11748,16 @@
       },
       "peerDependencies": {
         "next": ">=9.0.0"
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "next": "14.2.3",
     "next-nprogress-bar": "^2.3.13",
     "next-pwa": "^5.6.0",
+    "next-themes": "^0.4.6",
     "postcss": "^8.4.39",
     "prism-react-renderer": "^2.3.1",
     "react": "^18",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,6 +11,7 @@ import { Inter } from 'next/font/google';
 import Script from 'next/script';
 import styles from './layout.module.css';
 import { cn } from '@nextui-org/theme';
+import { ThemeProvider } from 'next-themes';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -87,16 +88,22 @@ export default function RootLayout({
   return (
     <html lang="en" className="h-full">
       <body
-        className={cn(inter.className, styles.safeArea, 'min-h-svh h-full')}
+        className={cn(
+          inter.className,
+          styles.safeArea,
+          'min-h-svh h-full',
+          'dark:bg-black dark:text-slate-400'
+        )}
       >
-        <ClientProgressProvider>
-          <ClientNextUIProvider>
-            <ClientQueryClientProvider>
-              <ClientToastProvider>{children}</ClientToastProvider>
-            </ClientQueryClientProvider>
-          </ClientNextUIProvider>
-        </ClientProgressProvider>
-
+        <ThemeProvider attribute="class">
+          <ClientProgressProvider>
+            <ClientNextUIProvider>
+              <ClientQueryClientProvider>
+                <ClientToastProvider>{children}</ClientToastProvider>
+              </ClientQueryClientProvider>
+            </ClientNextUIProvider>
+          </ClientProgressProvider>
+        </ThemeProvider>
         {process.env.NODE_ENV === 'production' && (
           <GoogleAnalytics gaId="G-X8PDBBD3R5" />
         )}

--- a/src/features/update-profile/ui/update-profile-image.tsx
+++ b/src/features/update-profile/ui/update-profile-image.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {
   Button,
+  cn,
   Image,
   Modal,
   ModalBody,
@@ -38,19 +39,18 @@ const UpdateProfileImage = ({
           src={src || '/no-image.svg'}
           alt="Profile"
           fallbackSrc="/no-image.svg"
-          className="
-          w-24 md:w-32
-          min-w-24 md:min-w-32
-          max-w-24 md:max-w-32
-          h-24 md:h-32
-          min-h-24 md:min-h-32
-          max-h-24 md:max-h-32
-          rounded-full
-          border-4
-          border-white
-          z-50
-          cursor-pointer
-          "
+          className={cn(
+            'w-24 md:w-32',
+            'min-w-24 md:min-w-32',
+            'max-w-24 md:max-w-32',
+            'h-24 md:h-32',
+            'min-h-24 md:min-h-32',
+            'max-h-24 md:max-h-32',
+            'rounded-full',
+            'border-4 dark:border-gray-700',
+            'z-50',
+            'cursor-pointer'
+          )}
           onClick={onOpen}
         />
         <Modal
@@ -97,19 +97,19 @@ const UpdateProfileImage = ({
           src={src || '/no-image.svg'}
           alt="Profile"
           fallbackSrc="/no-image.svg"
-          className="
-          w-24 md:w-32
-          min-w-24 md:min-w-32
-          max-w-24 md:max-w-32
-          h-24 md:h-32
-          min-h-24 md:min-h-32
-          max-h-24 md:max-h-32
-          rounded-full
-          border-4
-          border-white
-          z-50
-          cursor-pointer
-          "
+          className={cn(
+            'w-24 md:w-32',
+            'min-w-24 md:min-w-32',
+            'max-w-24 md:max-w-32',
+            'h-24 md:h-32',
+            'min-h-24 md:min-h-32',
+            'max-h-24 md:max-h-32',
+            'rounded-full',
+            'border-4',
+            'border dark:border-gray-700',
+            'z-50',
+            'cursor-pointer'
+          )}
         />
         <input type="file" onChange={onUpload} className="hidden" />
       </label>

--- a/src/features/wepp-comment/ui/delete-wepp-comment-button.tsx
+++ b/src/features/wepp-comment/ui/delete-wepp-comment-button.tsx
@@ -32,7 +32,12 @@ const WeppCommentDeleteButton = ({ commentId }: Props) => {
 
   return (
     <>
-      <Button size="sm" variant="light" onPress={onOpenChange}>
+      <Button
+        size="sm"
+        variant="light"
+        onPress={onOpenChange}
+        className="dark:text-gray-400"
+      >
         삭제
       </Button>
 

--- a/src/shared/layouts/developer/developer-layout-header.tsx
+++ b/src/shared/layouts/developer/developer-layout-header.tsx
@@ -18,7 +18,7 @@ const Header = () => {
           className="flex gap-2 items-center cursor-pointer"
           onClick={() => push(PATH.DEVELOPER.WEPP)}
         >
-          <LogoIcon width={36} height={36} aria-label="logo icon" />
+          <LogoIcon width={36} height={36} />
           <h1 className="text-xl font-semibold">Developer</h1>
         </div>
       </NavbarBrand>

--- a/src/shared/layouts/developer/developer-layout-header.tsx
+++ b/src/shared/layouts/developer/developer-layout-header.tsx
@@ -5,6 +5,8 @@ import AccountPopover from './account-popover';
 import { Navbar, NavbarBrand, NavbarContent, Image } from '@nextui-org/react';
 import { PATH } from '@/shared/constants';
 import { useRouter } from 'next/navigation';
+import { LogoIcon } from '@/shared/ui/icons';
+import { ThemeSwitcher } from '@/shared/ui/theme-switcher';
 
 const Header = () => {
   const { push } = useRouter();
@@ -13,14 +15,15 @@ const Header = () => {
     <Navbar isBordered maxWidth="full">
       <NavbarBrand className="gap-16 sm:hidden">
         <div
-          className="flex gap-4 items-center cursor-pointer"
+          className="flex gap-2 items-center cursor-pointer"
           onClick={() => push(PATH.DEVELOPER.WEPP)}
         >
-          <Image src="/logo.svg" alt="wepp store logo" width={28} height={28} />
+          <LogoIcon width={36} height={36} aria-label="logo icon" />
           <h1 className="text-xl font-semibold">Developer</h1>
         </div>
       </NavbarBrand>
-      <NavbarContent justify="end">
+      <NavbarContent justify="end" className="gap-6">
+        <ThemeSwitcher />
         <AccountPopover />
       </NavbarContent>
     </Navbar>

--- a/src/shared/layouts/developer/developer-layout-nav.tsx
+++ b/src/shared/layouts/developer/developer-layout-nav.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { Image, Listbox, ListboxItem } from '@nextui-org/react';
+import { Listbox, ListboxItem } from '@nextui-org/react';
 import { LayoutGrid, Wrench } from 'lucide-react';
 import { usePathname, useRouter } from 'next/navigation';
 import { PATH } from '@/shared/constants';
+import { LogoIcon } from '@/shared/ui/icons';
 
 const DeveloperLayoutNav = () => {
   const pathname = usePathname();
@@ -19,31 +20,17 @@ const DeveloperLayoutNav = () => {
   };
 
   const selectedClasses = (path: string) => {
-    return isActive(path) ? 'bg-gray-100' : 'text-default-500';
+    return isActive(path) ? 'bg-gray-100 dark:bg-gray-700' : 'text-default-500';
   };
 
   return (
     <>
-      <nav
-        className="
-        hidden sm:flex flex-col gap-4
-        p-4
-        border-r
-        sm:w-20
-        lg:min-w-[200px]
-      "
-      >
+      <nav className=" hidden sm:flex flex-col gap-4 p-4 border-r dark:border-gray-700 sm:w-20 lg:min-w-[200px]">
         <div
           className="h-20 flex gap-2 items-center justify-center cursor-pointer"
           onClick={() => replace(PATH.DEVELOPER.WEPP)}
         >
-          <Image
-            src="/logo.svg"
-            alt="wepp store logo"
-            width={28}
-            height={28}
-            className="aspect-square w-[28px] min-w-[28px] h-[28px]"
-          />
+          <LogoIcon width={36} height={36} aria-label="logo icon" />
           <h1 className="text-xl font-semibold text-nowrap hidden lg:inline">
             Developer
           </h1>

--- a/src/shared/layouts/developer/developer-layout-nav.tsx
+++ b/src/shared/layouts/developer/developer-layout-nav.tsx
@@ -30,7 +30,7 @@ const DeveloperLayoutNav = () => {
           className="h-20 flex gap-2 items-center justify-center cursor-pointer"
           onClick={() => replace(PATH.DEVELOPER.WEPP)}
         >
-          <LogoIcon width={36} height={36} aria-label="logo icon" />
+          <LogoIcon width={36} height={36} />
           <h1 className="text-xl font-semibold text-nowrap hidden lg:inline">
             Developer
           </h1>

--- a/src/shared/layouts/main/main-layout-footer.tsx
+++ b/src/shared/layouts/main/main-layout-footer.tsx
@@ -11,7 +11,7 @@ const MainLayoutFooter = () => {
         <p className="text-sm text-center">
           &copy; {new Date().getFullYear()} Wepp Store. All rights reserved.
         </p>
-        <div className="flex justify-end">
+        <div className="flex justify-end gap-2">
           <Button
             isIconOnly
             variant="light"

--- a/src/shared/layouts/main/main-layout-header.tsx
+++ b/src/shared/layouts/main/main-layout-header.tsx
@@ -25,7 +25,7 @@ const Header = ({ showMenu = true, showBackButton = false }: Props) => {
           className="flex gap-2 items-center cursor-pointer"
           onClick={() => push(PATH.MAIN.WEPPS)}
         >
-          <LogoIcon width={36} height={36} aria-label="logo icon" />
+          <LogoIcon width={36} height={36} />
           <h1 className="text-xl font-semibold">Wepp Store</h1>
         </div>
 

--- a/src/shared/layouts/main/main-layout-header.tsx
+++ b/src/shared/layouts/main/main-layout-header.tsx
@@ -1,15 +1,10 @@
 'use client';
-import {
-  Tab,
-  Tabs,
-  Image,
-  Navbar,
-  NavbarBrand,
-  NavbarContent,
-} from '@nextui-org/react';
+import { Navbar, NavbarBrand, NavbarContent } from '@nextui-org/react';
 import { usePathname, useRouter } from 'next/navigation';
 import AccountPopover from './account-popover';
 import { PATH } from '@/shared/constants';
+import { LogoIcon } from '@/shared/ui/icons';
+import { ThemeSwitcher } from '@/shared/ui/theme-switcher';
 
 interface Props {
   showMenu?: boolean;
@@ -30,7 +25,7 @@ const Header = ({ showMenu = true, showBackButton = false }: Props) => {
           className="flex gap-2 items-center cursor-pointer"
           onClick={() => push(PATH.MAIN.WEPPS)}
         >
-          <Image src="/logo.svg" alt="wepp store logo" width={28} height={28} />
+          <LogoIcon width={36} height={36} aria-label="logo icon" />
           <h1 className="text-xl font-semibold">Wepp Store</h1>
         </div>
 
@@ -52,7 +47,8 @@ const Header = ({ showMenu = true, showBackButton = false }: Props) => {
         </Tabs> */}
       </NavbarBrand>
 
-      <NavbarContent justify="end">
+      <NavbarContent justify="end" className="gap-6">
+        <ThemeSwitcher />
         <AccountPopover />
       </NavbarContent>
     </Navbar>

--- a/src/shared/ui/callout.tsx
+++ b/src/shared/ui/callout.tsx
@@ -75,4 +75,4 @@ const Callout: React.FC<CalloutProps> = ({
   );
 };
 
-export default Callout;
+export { Callout };

--- a/src/shared/ui/callout/index.ts
+++ b/src/shared/ui/callout/index.ts
@@ -1,1 +1,0 @@
-export { default as Callout } from './callout';

--- a/src/shared/ui/icons/index.ts
+++ b/src/shared/ui/icons/index.ts
@@ -1,0 +1,1 @@
+export { default as LogoIcon } from './logo';

--- a/src/shared/ui/icons/logo.tsx
+++ b/src/shared/ui/icons/logo.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+const LogoIcon = (props?: React.SVGProps<SVGSVGElement>) => {
+  return (
+    <svg
+      width="48"
+      height="48"
+      viewBox="0 0 48 48"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <rect
+        x="18.1875"
+        y="13.5938"
+        width="11.625"
+        height="11.625"
+        rx="5.8125"
+        stroke="currentColor"
+        strokeWidth="3.375"
+      />
+      <path
+        d="M9.75 18.5366C9.75 6.93231 19.3125 6 24.0938 6C28.875 6 38.4375 6.93231 38.4375 18.5366C38.4375 30.1408 28.875 38.9515 24.0938 41.9062C19.3125 38.9515 9.75 30.1408 9.75 18.5366Z"
+        stroke="currentColor"
+        strokeWidth="3"
+      />
+    </svg>
+  );
+};
+
+export default LogoIcon;

--- a/src/shared/ui/icons/logo.tsx
+++ b/src/shared/ui/icons/logo.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 const LogoIcon = (props?: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg
+      aria-label="Logo"
       width="48"
       height="48"
       viewBox="0 0 48 48"

--- a/src/shared/ui/keyboard-adjust-button.tsx
+++ b/src/shared/ui/keyboard-adjust-button.tsx
@@ -52,4 +52,4 @@ const KeyboardAdjustButton: React.FC<ButtonProps> = ({
   );
 };
 
-export default KeyboardAdjustButton;
+export { KeyboardAdjustButton };

--- a/src/shared/ui/keyboard-adjust-button/index.ts
+++ b/src/shared/ui/keyboard-adjust-button/index.ts
@@ -1,1 +1,0 @@
-export { default as KeyboardAdjustButton } from './keyboard-adjust-button';

--- a/src/shared/ui/section.tsx
+++ b/src/shared/ui/section.tsx
@@ -23,4 +23,4 @@ const Section: React.FC<Props> = ({ children, className = '', ...other }) => {
   );
 };
 
-export default Section;
+export { Section };

--- a/src/shared/ui/section/index.ts
+++ b/src/shared/ui/section/index.ts
@@ -1,1 +1,0 @@
-export { default as Section } from './section';

--- a/src/shared/ui/theme-switcher.tsx
+++ b/src/shared/ui/theme-switcher.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { Moon, Sun } from 'lucide-react';
+import { useTheme } from 'next-themes';
+
+function ThemeSwitcher() {
+  const { theme, setTheme } = useTheme();
+
+  const handleModeSwitch = () => {
+    if ('startViewTransition' in document) {
+      document.startViewTransition(() => {
+        setTheme((theme) => (theme === 'light' ? 'dark' : 'light'));
+      });
+      return;
+    }
+    setTheme((theme) => (theme === 'light' ? 'dark' : 'light'));
+  };
+
+  return (
+    <button
+      suppressHydrationWarning
+      onClick={handleModeSwitch}
+      type="button"
+      aria-label="Theme Switcher"
+    >
+      {theme === 'light' ? <Sun /> : <Moon />}
+    </button>
+  );
+}
+
+export { ThemeSwitcher };

--- a/src/views/(auth)/login/login-page.tsx
+++ b/src/views/(auth)/login/login-page.tsx
@@ -24,7 +24,7 @@ const LoginPage = () => {
       </Button>
       <div className="flex flex-col items-center gap-8">
         <div className="flex flex-col justify-center items-center">
-          <LogoIcon width={52} height={52} aria-label="logo icon" />
+          <LogoIcon width={52} height={52} />
           <h1 className="mt-2 text-3xl font-bold">로그인</h1>
         </div>
         <Card className="shadow-none border dark:border-gray-700">

--- a/src/views/(auth)/login/login-page.tsx
+++ b/src/views/(auth)/login/login-page.tsx
@@ -7,23 +7,13 @@ import { ChevronLeft } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { PATH } from '@/shared/constants';
 import { LoginForm } from './sections';
+import { LogoIcon } from '@/shared/ui/icons';
 
 const LoginPage = () => {
   const router = useRouter();
 
   return (
-    <div
-      className="
-        fixed
-        w-full
-        h-full
-        top-0
-        left-0
-        flex justify-center items-center
-        bg-white
-        z-50
-    "
-    >
+    <div className=" fixed w-full h-full top-0 left-0 flex justify-center items-center z-50">
       <Button
         isIconOnly
         className="absolute top-3 left-3"
@@ -34,18 +24,17 @@ const LoginPage = () => {
       </Button>
       <div className="flex flex-col items-center gap-8">
         <div className="flex flex-col justify-center items-center">
-          <Image src="/logo.svg" width={64} height={64} alt="logo" />
-          <h1 className="text-3xl font-bold">로그인</h1>
+          <LogoIcon width={52} height={52} aria-label="logo icon" />
+          <h1 className="mt-2 text-3xl font-bold">로그인</h1>
         </div>
-        <Card>
+        <Card className="shadow-none border dark:border-gray-700">
           <CardBody>
             <div className="flex flex-col gap-2">
               <LoginForm />
-              <div className="relative my-6">
-                <Divider />
-                <span className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 bg-white px-2 text-sm text-gray-500">
-                  또는
-                </span>
+              <div className="my-6 flex items-center">
+                <Divider className="w-auto flex-1" />
+                <span className="px-2 text-sm text-gray-500">또는</span>
+                <Divider className="w-auto flex-1" />
               </div>
               <GoogleLoginButton />
             </div>

--- a/src/views/(auth)/login/sections/login-form.tsx
+++ b/src/views/(auth)/login/sections/login-form.tsx
@@ -57,7 +57,7 @@ const LoginForm = () => {
 
           <p className="text-center text-small">
             계정이 없으신가요?{' '}
-            <Link size="sm" href="/sign-up">
+            <Link size="sm" href="/sign-up" className="dark:text-gray-400">
               회원가입
             </Link>
           </p>
@@ -65,10 +65,10 @@ const LoginForm = () => {
 
         <div className="flex flex-col justify-end">
           <Button
-            color="primary"
             type="submit"
             fullWidth
             isLoading={signInMutation.isPending}
+            className="bg-black text-white dark:bg-default"
           >
             {signInMutation.isPending || '로그인하기'}
           </Button>

--- a/src/views/(auth)/sign-up/sign-up-page.tsx
+++ b/src/views/(auth)/sign-up/sign-up-page.tsx
@@ -5,9 +5,7 @@ import { EmailStep, NameStep, PasswordStep, VerifyEmailStep } from './sections';
 import { useForm } from 'react-hook-form';
 import { signUpSchema, useSignUpStepStore } from './lib';
 import { FormProvider } from '@/shared/ui/hook-form';
-import { Image, Link } from '@nextui-org/react';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { PATH } from '@/shared/constants';
 
 const SignUpPage = () => {
   const step = useSignUpStepStore((state) => state.step);
@@ -20,41 +18,18 @@ const SignUpPage = () => {
   const onSubmit = () => {};
 
   return (
-    <div
-      className="
-        size-full max-w-screen-md
-        box-border
-        mx-auto
-        flex sm:items-center
-      "
-    >
-      <div className="flex grow sm:h-96">
-        <div className="flex-1 p-4 hidden sm:flex bg-gradient-to-tr from-primary-100 rounded-l-lg">
-          <div className="flex flex-col grow items-center justify-between">
-            <div className="flex flex-col items-center">
-              <Image src="/logo.svg" width={64} height={64} alt="logo" />
-              <h1 className="text-3xl font-bold text-gray-900">회원가입</h1>
-            </div>
-            <Link
-              href={PATH.AUTH.LOGIN}
-              className="mt-4 text-gray-600 underline"
-            >
-              로그인 페이지로 이동하기
-            </Link>
-          </div>
-        </div>
-        <div className="flex-1 py-4">
-          <FormProvider
-            className="size-full"
-            methods={methods}
-            onSubmit={methods.handleSubmit(onSubmit)}
-          >
-            {step === 0 && <EmailStep />}
-            {step === 1 && <VerifyEmailStep />}
-            {step === 2 && <NameStep />}
-            {step === 3 && <PasswordStep />}
-          </FormProvider>
-        </div>
+    <div className="size-full max-w-md box-border mx-auto flex">
+      <div className="flex-1 py-4">
+        <FormProvider
+          className="size-full"
+          methods={methods}
+          onSubmit={methods.handleSubmit(onSubmit)}
+        >
+          {step === 0 && <EmailStep />}
+          {step === 1 && <VerifyEmailStep />}
+          {step === 2 && <NameStep />}
+          {step === 3 && <PasswordStep />}
+        </FormProvider>
       </div>
     </div>
   );

--- a/src/views/(end-user)/main/sections/main-jumbotron-section.tsx
+++ b/src/views/(end-user)/main/sections/main-jumbotron-section.tsx
@@ -95,7 +95,7 @@ const MainJumbotronSection = () => {
             size="lg"
             color="default"
             variant="solid"
-            className="bg-black text-white rounded-lg"
+            className="bg-black text-white dark:bg-default rounded-lg"
             onPress={onClickBrowse}
           >
             <Sparkles className="mr-2 h-5 w-5" />

--- a/src/views/(end-user)/main/ui/wepp-card.tsx
+++ b/src/views/(end-user)/main/ui/wepp-card.tsx
@@ -19,7 +19,7 @@ const WeppCard = ({ wepp, href }: Props) => {
       as={Link}
       href={href}
       isPressable
-      className="border-none shadow-none bg-gray-100 hover:bg-gray-200 transition-all duration-200 ease-in-out"
+      className="border-none shadow-none bg-gray-100 dark:bg-gray-800 hover:-translate-y-1 transition-all duration-200 ease-in-out"
     >
       <CardBody className="flex-row gap-4">
         <Image

--- a/src/views/(end-user)/profile/sections/profile-about-section.tsx
+++ b/src/views/(end-user)/profile/sections/profile-about-section.tsx
@@ -8,10 +8,10 @@ interface Props {
 
 const ProfileAboutSection = ({ profile }: Props) => {
   return (
-    <Card className="mt-4 shadow-sm border">
+    <Card className="mt-4 shadow-sm border dark:border-gray-700">
       <CardBody className="p-6">
         <h2 className="text-xl font-bold mb-4">소개</h2>
-        <p className="text-gray-700">
+        <p className="text-gray-700 dark:text-gray-400">
           {profile?.description || '소개가 없습니다.'}
         </p>
       </CardBody>

--- a/src/views/(end-user)/profile/sections/profile-basic-section.tsx
+++ b/src/views/(end-user)/profile/sections/profile-basic-section.tsx
@@ -15,12 +15,14 @@ const ProfileBasicSection = ({ profile, isMine = false }: Props) => {
   const isFetched = !!profile;
 
   return (
-    <Card className="mt-4 shadow-sm border">
+    <Card className="mt-4 shadow-sm border dark:border-gray-700">
       <CardBody className="p-6 flex-row gap-8">
         <UpdateProfileImage src={profile?.profileUrl} isMine={isMine} />
         <div className="grow flex flex-col">
           <h1 className="text-2xl font-bold">{profile?.userName}</h1>
-          <p className="text-gray-600 grow">{profile?.email}</p>
+          <p className="grow text-gray-600 dark:text-gray-400">
+            {profile?.email}
+          </p>
           <div className="mt-4 flex justify-end gap-4 self-end">
             {isMine && (
               <Skeleton isLoaded={isFetched} className="rounded-lg">

--- a/src/views/(end-user)/profile/sections/profile-wepps-section.tsx
+++ b/src/views/(end-user)/profile/sections/profile-wepps-section.tsx
@@ -16,14 +16,14 @@ const ProfileWeppsSection = ({ profile }: Props) => {
   }
 
   return (
-    <Card className="mt-4 shadow-sm border">
+    <Card className="mt-4 shadow-sm border dark:border-gray-700">
       <CardBody className="p-6">
         <h2 className="text-xl font-bold mb-4">만든 앱</h2>
-        <div className="flex flex-col">
+        <div className="flex flex-col gap-1">
           {wepps.map((wepp) => (
             <Link
               key={wepp.id}
-              className="flex items-center hover:bg-gray-100 p-2 rounded-lg"
+              className="flex items-center p-2 rounded-lg hover:-translate-y-1 transition-transform duration-200"
               href={PATH.MAIN.WEPP_DETAIL(wepp.id)}
             >
               <img

--- a/src/views/(end-user)/wepp-detail/sections/wepp-detail-additional-info.tsx
+++ b/src/views/(end-user)/wepp-detail/sections/wepp-detail-additional-info.tsx
@@ -39,10 +39,14 @@ const WeppDetailAdditionalInfo = ({ wepp }: Props) => {
         </div>
 
         <span className="ml-4 font-bold">·</span>
-        <p className="ml-2 text-gray-500">릴리즈 {releasedDate}</p>
+        <p className="ml-2 text-gray-500 dark:text-gray-400">
+          릴리즈 {releasedDate}
+        </p>
 
         <span className="ml-4 font-bold">·</span>
-        <p className="ml-2 text-gray-500">버전 {wepp?.version}</p>
+        <p className="ml-2 text-gray-500 dark:text-gray-400">
+          버전 {wepp?.version}
+        </p>
       </div>
     </Section>
   );

--- a/src/views/(end-user)/wepp-detail/sections/wepp-detail-comments.tsx
+++ b/src/views/(end-user)/wepp-detail/sections/wepp-detail-comments.tsx
@@ -33,7 +33,7 @@ const WeppDetailComments = () => {
         ))}
       {hasNextPage && (
         <button
-          className="flex items-center mt-4 mb-2 text-sm text-gray-700"
+          className="flex items-center mt-4 mb-2 text-sm text-gray-700 dark:text-gray-400"
           onClick={() => fetchNextPage()}
         >
           {/* divider */}

--- a/src/views/(end-user)/wepp-detail/sections/wepp-detail-description.tsx
+++ b/src/views/(end-user)/wepp-detail/sections/wepp-detail-description.tsx
@@ -13,16 +13,24 @@ const WeppDetailDescription = ({ wepp }: Props) => {
   return (
     <Section>
       {/* <h3 className="text-lg font-semibold mb-2">앱 설명</h3> */}
-      <p className="text-gray-700 mb-4">{description}</p>
+      <p className="text-gray-700 dark:text-gray-400 mb-4">{description}</p>
 
       <div className="mt-8 flex gap-4 items-center">
         {isMobile && (
-          <Chip className="bg-gray-200 rounded-md">#모바일 호환</Chip>
+          <Chip className="bg-gray-200 dark:bg-gray-800 rounded-md">
+            #모바일 호환
+          </Chip>
         )}
         {isTablet && (
-          <Chip className="bg-gray-200 rounded-md">#태블릿 호환</Chip>
+          <Chip className="bg-gray-200 dark:bg-gray-800 rounded-md">
+            #태블릿 호환
+          </Chip>
         )}
-        {isDesktop && <Chip className="bg-gray-200 rounded-md">#PC 호환</Chip>}
+        {isDesktop && (
+          <Chip className="bg-gray-200 dark:bg-gray-800 rounded-md">
+            #PC 호환
+          </Chip>
+        )}
       </div>
     </Section>
   );

--- a/src/views/(end-user)/wepp-detail/sections/wepp-detail-title.tsx
+++ b/src/views/(end-user)/wepp-detail/sections/wepp-detail-title.tsx
@@ -63,7 +63,7 @@ const WeppDetailTitle = ({ wepp }: Props) => {
 
       <div className="flex justify-between items-center min-w-48">
         <div className="flex items-center gap-2 text-gray-600">
-          <span className="">
+          <span className="text-gray-500 dark:text-gray-400">
             {(categories ?? [])
               .slice(0, 2)
               .map((c) => c.name)
@@ -71,23 +71,20 @@ const WeppDetailTitle = ({ wepp }: Props) => {
           </span>
 
           {(categories ?? []).length > 2 && (
-            <span className="text-gray-500">
+            <span className="text-gray-500 dark:text-gray-400">
               외 {(categories ?? []).length - 2}개
             </span>
           )}
 
           <span className="font-bold">·</span>
 
-          <div className="flex gap-3 text-gray-600">
-            <span
-              className="flex items-center gap-1 text-gray-500"
-              aria-label="좋아요 수"
-            >
+          <div className="flex gap-3 text-gray-600 dark:text-gray-400">
+            <span className="flex items-center gap-1" aria-label="좋아요 수">
               <WeppLikeButton />
               {_count?.likes || 0}
             </span>
             <span
-              className="flex items-center gap-1 text-gray-500"
+              className="flex items-center gap-1 text-gray-500 dark:text-gray-400"
               aria-label="댓글 수"
             >
               <MessageCircle

--- a/src/views/(end-user)/wepp-detail/ui/wepp-comment-replies.tsx
+++ b/src/views/(end-user)/wepp-detail/ui/wepp-comment-replies.tsx
@@ -44,7 +44,7 @@ const WeppCommentReplies = ({ commentId, show }: Props) => {
 
       {hasNextPage && (
         <button
-          className="flex items-center mt-4 mb-2 text-sm text-gray-700"
+          className="flex items-center mt-4 mb-2 text-sm text-gray-700 dark:text-gray-400"
           onClick={() => fetchNextPage()}
         >
           {/* divider */}
@@ -101,7 +101,7 @@ const ReplyComment = ({ comment }: { comment: IComment }) => {
               <p className="font-gray-800">
                 {mention && (
                   <span
-                    className="text-sm text-gray-500"
+                    className="text-sm text-gray-500 dark:text-gray-400"
                     aria-label={String(parseMention(mention).id)}
                   >
                     @{parseMention(mention).name}{' '}
@@ -109,7 +109,7 @@ const ReplyComment = ({ comment }: { comment: IComment }) => {
                 )}
                 {content}
               </p>
-              <div className="flex gap-2 mt-1 text-xs text-gray-500">
+              <div className="flex gap-2 mt-1 text-xs text-gray-500 dark:text-gray-400">
                 <time>{timeAgo(createdAt)}</time>
                 <div
                   role="button"

--- a/src/views/(end-user)/wepp-detail/ui/wepp-comment.tsx
+++ b/src/views/(end-user)/wepp-detail/ui/wepp-comment.tsx
@@ -68,7 +68,7 @@ const WeppComment = ({ comment }: Props) => {
                 <p className="font-gray-800">
                   {mention && (
                     <span
-                      className="text-sm text-gray-500"
+                      className="text-sm text-gray-500 dark:text-gray-400"
                       aria-label={String(parseMention(mention).id)}
                     >
                       @{parseMention(mention).name}{' '}
@@ -76,7 +76,7 @@ const WeppComment = ({ comment }: Props) => {
                   )}
                   {content}
                 </p>
-                <div className="flex gap-2 mt-1 text-xs text-gray-500">
+                <div className="flex gap-2 mt-1 text-xs text-gray-500 dark:text-gray-400">
                   <time>{timeAgo(createdAt)}</time>
                   <div
                     role="button"
@@ -103,7 +103,7 @@ const WeppComment = ({ comment }: Props) => {
               <>
                 <div
                   role="button"
-                  className="flex items-center mt-4 mb-2 text-sm text-gray-700"
+                  className="flex items-center mt-4 mb-2 text-sm text-gray-700 dark:text-gray-400 cursor-pointer"
                   onClick={() => setIsShowReply((v) => !v)}
                 >
                   {/* divider */}

--- a/src/views/(end-user)/wepp-detail/wepp-detail-page.tsx
+++ b/src/views/(end-user)/wepp-detail/wepp-detail-page.tsx
@@ -54,7 +54,7 @@ const WeppDetailScreen = () => {
       ) : (
         <Section>
           <h3 className="text-lg font-semibold mb-2">댓글</h3>
-          <div className="flex justify-center items-center bg-gray-100 rounded-md h-20">
+          <div className="flex justify-center items-center bg-gray-100 dark:bg-gray-800 rounded-md h-20">
             <p>
               댓글을 작성하려면{' '}
               <span id={ELEMENT_ID.CREATE_COMMENT_FIELD}>

--- a/src/views/developer/main/sections/developer-main-header.tsx
+++ b/src/views/developer/main/sections/developer-main-header.tsx
@@ -10,14 +10,7 @@ const DeveloperMainHeader = () => {
   return (
     <>
       <Section className="flex justify-between">
-        <h2
-          className="
-          text-3xl
-          font-bold
-          text-gray-800
-          mb-4
-          "
-        >
+        <h2 className="mb-4 text-3xl font-bold text-gray-800 dark:text-gray-200">
           {me?.userName}님의 앱
         </h2>
         <div className="flex gap-4">

--- a/src/views/developer/main/ui/developer-wepp-card.tsx
+++ b/src/views/developer/main/ui/developer-wepp-card.tsx
@@ -17,7 +17,7 @@ const DeveloperWeppCard = ({ wepp }: Props) => {
       as={Link}
       href={PATH.DEVELOPER.WEPP_DASHBOARD(id)}
       isPressable
-      className="border-none shadow-none bg-gray-100 hover:bg-gray-200 transition-all duration-200 ease-in-out"
+      className="border-none shadow-none bg-gray-100 dark:bg-gray-700 hover:-translate-y-1 transition-all duration-200 ease-in-out"
     >
       <CardBody className="flex flex-row justify-between gap-8">
         <Image
@@ -40,20 +40,22 @@ const DeveloperWeppCard = ({ wepp }: Props) => {
                 {weppStatusToText(status)}
               </Chip>
             </div>
-            <p className="mt-2 text-sm text-gray-500">{tagLine}</p>
+            <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
+              {tagLine}
+            </p>
           </div>
 
           {/* counts */}
           <div className="flex gap-2 text-gray-500 text-sm">
             <span
-              className="flex items-center gap-1 text-gray-500"
+              className="flex items-center gap-1 text-gray-500 dark:text-gray-400"
               aria-label="좋아요 수"
             >
               <Heart size={12} />
               {_count?.likes || 0}
             </span>
             <span
-              className="flex items-center gap-1 text-gray-500"
+              className="flex items-center gap-1 text-gray-500 dark:text-gray-400"
               aria-label="댓글 수"
             >
               <MessageCircle size={12} />

--- a/src/views/developer/make-pwa/step/manifest-step.tsx
+++ b/src/views/developer/make-pwa/step/manifest-step.tsx
@@ -252,12 +252,7 @@ const ManifestStep = () => {
           <ModalHeader>Manifest.json</ModalHeader>
           <ModalBody>
             <div className="flex justify-end gap-4">
-              <Button
-                size="sm"
-                color="primary"
-                variant="bordered"
-                onPress={handleDownload}
-              >
+              <Button size="sm" variant="bordered" onPress={handleDownload}>
                 다운로드
               </Button>
               <Button size="sm" color="primary" onPress={handleCopy}>

--- a/src/views/developer/wepp-dashboard/sections/wepp-dashboard-header.tsx
+++ b/src/views/developer/wepp-dashboard/sections/wepp-dashboard-header.tsx
@@ -22,7 +22,7 @@ const WeppDashboardHeader = () => {
     <Section>
       <header className="flex justify-between">
         <div className="flex gap-2 items-center">
-          <h1 className="text-3xl font-bold text-gray-800">
+          <h1 className="text-3xl font-bold text-gray-800 dark:text-gray-300">
             {wepp?.name} 대시보드
           </h1>
           <Chip

--- a/src/views/developer/wepp-dashboard/sections/wepp-dashboard-statistics.tsx
+++ b/src/views/developer/wepp-dashboard/sections/wepp-dashboard-statistics.tsx
@@ -17,28 +17,28 @@ const WeppDashboardStatistics = () => {
   return (
     <Section>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-        <Card className="p-4 flex-row items-center gap-6 border border-gray-200 rounded-md shadow-none">
+        <Card className="p-4 flex-row items-center gap-6 rounded-md shadow-none border border-gray-200 dark:border-gray-700 dark:text-gray-300">
           <Eye className="text-green-500" size={24} />
           <div>
             <p className="text-sm text-muted-foreground">총 조회 수</p>
             <p className="text-xl font-semibold">{viewCount ?? 0}회</p>
           </div>
         </Card>
-        <Card className="p-4 flex-row items-center gap-6 border border-gray-200 rounded-md shadow-none">
+        <Card className="p-4 flex-row items-center gap-6 rounded-md shadow-none border border-gray-200 dark:border-gray-700 dark:text-gray-300">
           <Heart className="text-red-500" size={24} />
           <div>
             <p className="text-sm text-muted-foreground">총 좋아요 수</p>
             <p className="text-xl font-semibold">{_count?.likes ?? 0}회</p>
           </div>
         </Card>
-        <Card className="p-4 flex-row items-center gap-6 border border-gray-200 rounded-md shadow-none">
+        <Card className="p-4 flex-row items-center gap-6 rounded-md shadow-none border border-gray-200 dark:border-gray-700 dark:text-gray-300">
           <MessageCircle className="text-purple-500" size={24} />
           <div>
             <p className="text-sm text-muted-foreground">총 댓글 수</p>
             <p className="text-xl font-semibold">{_count?.comments ?? 0}개</p>
           </div>
         </Card>
-        <Card className="p-4 flex-row items-center gap-6 border border-gray-200 rounded-md shadow-none">
+        <Card className="p-4 flex-row items-center gap-6 rounded-md shadow-none border border-gray-200 dark:border-gray-700 dark:text-gray-300">
           <BarChart2 className="text-blue-500" size={24} />
           <div>
             <p className="text-sm text-muted-foreground">

--- a/src/views/developer/wepp-info/sections/update-wepp-other-developers-section.tsx
+++ b/src/views/developer/wepp-info/sections/update-wepp-other-developers-section.tsx
@@ -78,7 +78,7 @@ const UpdateWeppOtherDevelopersSection = () => {
           {otherDevelopers?.map((developer, index) => (
             <div
               key={index}
-              className="flex items-center justify-between p-2 border rounded-lg border-gray-300"
+              className="flex items-center justify-between p-2 border rounded-lg border-gray-300 dark:border-gray-700"
             >
               <User
                 avatarProps={{

--- a/src/views/developer/wepp-info/sections/update-wepp-screenshots-section.tsx
+++ b/src/views/developer/wepp-info/sections/update-wepp-screenshots-section.tsx
@@ -35,7 +35,7 @@ const UpdateWeppScreenshotsSection = () => {
     <Section>
       <h2 className="text-xl font-semibold mb-4">스크린샷 (최대 5개)</h2>
       <WeppScreenshotDropzone>
-        <div className="flex gap-4 p-4 bg-gray-200 rounded-lg overflow-x-auto">
+        <div className="flex gap-4 p-4 bg-gray-200 dark:bg-gray-800 rounded-lg overflow-x-auto">
           <AddWeppScreenshot />
 
           <DragDropContext onDragEnd={onDragEnd}>

--- a/src/views/developer/wepp-info/ui/add-wepp-screenshot.tsx
+++ b/src/views/developer/wepp-info/ui/add-wepp-screenshot.tsx
@@ -48,7 +48,7 @@ const AddWeppScreenshot = () => {
   return (
     <label>
       <Button
-        className="w-40 h-72 bg-gray-100 self-center"
+        className="w-40 h-72 bg-gray-100 dark:bg-gray-700 self-center"
         onPress={() => addInputRef?.current?.click()}
       >
         <Plus />

--- a/src/views/developer/wepp-info/wepp-info-page.tsx
+++ b/src/views/developer/wepp-info/wepp-info-page.tsx
@@ -52,11 +52,12 @@ const WeppInfoPage = () => {
         <FormProvider methods={methods}>
           <Card className="border-none shadow-none rounded-md">
             <CardHeader className="flex justify-between items-center p-4">
-              <h1 className="text-3xl font-bold text-gray-800">앱 정보</h1>
+              <h1 className="text-3xl font-bold text-gray-800 dark:text-gray-300">
+                앱 정보
+              </h1>
 
               <div className="flex items-center gap-4">
                 <Button
-                  color="primary"
                   variant="bordered"
                   isLoading={patchWeppMutation.isPending}
                   onPress={() =>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -14,10 +14,11 @@ export default {
         //   DEFAULT: "#F3F4F6",
         //   foreground: "#fff",
         // }
-        primary: {
-          DEFAULT: '#000',
-          foreground: '#fff',
-        },
+        // primary: {
+        //   DEFAULT: '#000',
+        //   foreground: '#fff',
+        //   background: '#ff0000',
+        // },
       },
       aspectRatio: {
         mobile: '9 / 16',
@@ -28,6 +29,24 @@ export default {
   },
   plugins: [
     nextui({
+      themes: {
+        light: {
+          colors: {
+            primary: {
+              DEFAULT: '#000',
+              foreground: '#fff',
+            },
+          },
+        },
+        dark: {
+          colors: {
+            primary: {
+              DEFAULT: '#3f3f46',
+              foreground: '#fff',
+            },
+          },
+        },
+      },
       layout: {
         // radius: {
         //   small: "0.125rem",


### PR DESCRIPTION
# 다크모드 추가

- 로고 이미지를 svg 컴포넌트로 변경 (theme 모드에 맞도록 로고 색상을 적용하기 위해)
- 레이아웃 헤더에 `theme switcher` 추가

---

## 메인 페이지

![image](https://github.com/user-attachments/assets/ee471d84-d6cb-48e7-b9cb-0a494af46517)

---

## 개발자 앱 대시보드

![image](https://github.com/user-attachments/assets/e0b10d66-1c7f-4d56-bcf0-afead28a871f)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added theme switching functionality, allowing users to toggle between light and dark modes.
  - Introduced a new custom logo icon throughout the application.

- **Enhancements**
  - Comprehensive dark mode support added across all major pages and components for improved readability and visual consistency.
  - Updated button, card, and text styles to adapt automatically to the selected theme.
  - Improved hover and interaction effects for a more modern user experience.

- **UI Updates**
  - Simplified and modernized layouts on authentication and profile pages.
  - Enhanced navigation and header sections with theme switching and updated branding.

- **Chores**
  - Updated dependencies to support theming capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->